### PR TITLE
refactor: shard -> shard_id

### DIFF
--- a/shardman/__init__.py
+++ b/shardman/__init__.py
@@ -99,7 +99,7 @@ async def connect(token: str):
         await Shard(shard_id=shard_id, session_id=session_id, last_beat=last_beat).insert()
 
         return ConnectConfirmed(
-            shard=shard_id, max_shards=total_shards, session_id=session_id, sleep_duration=sleep_duration
+            shard_id=shard_id, max_shards=total_shards, session_id=session_id, sleep_duration=sleep_duration
         )
 
 

--- a/shardman/responses.py
+++ b/shardman/responses.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 
 
 class ConnectConfirmed(BaseModel):
-    shard: int
+    shard_id: int
     max_shards: int
     session_id: str
     sleep_duration: float = 0.0


### PR DESCRIPTION
it seems to be used as a shard_id, why not name it that way

This breaks #3 