### PR TITLE
docs: correct request params to use json not data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ headers = {
   'Authorization': 'SECRET',
 }
 
-r = requests.post('/beat', data={
+r = requests.post('/beat', json={
   'session_id': 'string'
 }, headers = headers)
 


### PR DESCRIPTION
This drove me up the wall trying to work out what was wrong... hopefully this saves future generations 