### PR TITLE
refactor!: Make disconnect api consistent with beat

### DIFF
--- a/shardman/__init__.py
+++ b/shardman/__init__.py
@@ -8,7 +8,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 
 from shardman.config import load_config
 from shardman.models import Shard, all_models
-from shardman.requests import Heartbeat
+from shardman.requests import Heartbeat, SessionID
 from shardman.responses import ConnectConfirmed, Status, ShardProjection
 from shardman.state import AlertType, StateManager
 
@@ -134,8 +134,8 @@ async def beat(heartbeat: Heartbeat) -> None:
     },
     dependencies=[Depends(requires_authorization)],
 )
-async def disconnect(session_id: str) -> None:
-    shard = await Shard.find_one(Shard.session_id == session_id)
+async def disconnect(resp: SessionID) -> None:
+    shard = await Shard.find_one(Shard.session_id == resp.session_id)
     if not shard:
         raise HTTPException(status_code=404, detail="Session Not Found")
 

--- a/shardman/requests.py
+++ b/shardman/requests.py
@@ -9,3 +9,8 @@ class Heartbeat(BaseModel):
     latency: float | None = None
 
     extra: Any | None = None
+
+
+class SessionID(BaseModel):
+    session_id: str
+


### PR DESCRIPTION
Beat and disconnect had a different api schema, this makes them the same. The result of this is that to interact with both disconnect and beat you use `request.post(..., json={...})` instead of swithcing between data= and json=