### PR TITLE
feat: add 2 utility routes [ total servers & gateway info ]

### DIFF
--- a/shardman/__init__.py
+++ b/shardman/__init__.py
@@ -150,3 +150,14 @@ async def status(extra: bool = False) -> Status:
     shards = await Shard.find_all().project(ShardProjection).to_list()
 
     return Status(total_shards=state.total_shards, shards=shards)
+
+
+@api.get("/total_guilds", status_code=200, dependencies=[Depends(requires_authorization)])
+async def total_guilds() -> int:
+    shards = await Shard.find_all().project(ShardProjection).to_list()
+    return sum(shard.guild_count for shard in shards)
+
+
+@api.get("/gateway_info", status_code=200, dependencies=[Depends(requires_authorization)])
+async def gateway_info() -> dict:
+    return await state.get_bot_info()

--- a/shardman/state.py
+++ b/shardman/state.py
@@ -68,13 +68,14 @@ class StateManager:
                 data=json.dumps(embed),
             )
 
-    async def get_bot_info(self) -> None:
+    async def get_bot_info(self) -> dict:
         """Get bot info using bot token."""
         resp = await self.__session.get("/api/v10/gateway/bot")
         data = await resp.json()
         resp.raise_for_status()
         self.total_shards = self._config.max_shards or data.get("shards")
         self.max_concurrency = data.get("session_start_limit").get("max_concurrency")
+        return data
 
     async def get_shard_id(self) -> int | None:
         """Get needed shard ID, if any are available"""


### PR DESCRIPTION
Adds 2 new useful routes to the api 

`/total_guilds` - returns the sum of all shard's guilds 
`/gateway_info` - returns the result of `/api/v10/gateway/bot`

A side effect of this pr is that it makes state.get_bot_info return its received payload. 